### PR TITLE
updates, part 2

### DIFF
--- a/engine/h2shared/cd_sdl.c
+++ b/engine/h2shared/cd_sdl.c
@@ -33,7 +33,7 @@
 
 /* SDL dropped support for
    cd audio since v1.3.0 */
-#warning SDL CDAudio support disabled
+#pragma message("Warning: SDL CDAudio support disabled")
 #include "cd_null.c"
 
 #else	/* SDL_INIT_CDROM */

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -49,8 +49,7 @@ OSLIBS:=$(UHEXEN2_TOP)/oslibs
 # X directory
 X11BASE    =/usr/X11R6
 
-# which major SDL version to use
-# ignored for legacy platforms without SDL2 support
+# which major SDL version to use (1: SDL-1.2, 2: SDL-2.0)
 SDL_API    = 2
 
 # the sdl-config command
@@ -508,9 +507,16 @@ LDFLAGS += -s
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # using SDL for now:
-SDL_API=1
-SDL_CFLAGS=-I$(OSLIBS)/os2/SDL/include
-SDL_LIBS = -L$(OSLIBS)/os2/SDL/lib -lSDL12
+ifeq ($(SDL_API),2)
+SDL_DIR=SDL2
+LIB_SDL=SDL2
+else
+SDL_DIR=SDL
+LIB_SDL=SDL12
+endif
+
+SDL_CFLAGS=-I$(OSLIBS)/os2/$(SDL_DIR)/include
+SDL_LIBS = -L$(OSLIBS)/os2/$(SDL_DIR)/lib -l$(LIB_SDL)
 USE_SDLCD=yes
 USE_SDLAUDIO=yes
 
@@ -859,6 +865,7 @@ ifeq ($(TARGET_OS),morphos)
 
 # MorphOS builds can use SDL or native code
 USE_SDL=no
+# Use SDL-1.2 for now, if actually using SDL.
 SDL_API=1
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no
@@ -936,6 +943,7 @@ ifeq ($(TARGET_OS),aros)
 
 # AROS builds can use SDL or native code
 USE_SDL=no
+# Use SDL-1.2 for now, if actually using SDL.
 SDL_API=1
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no
@@ -1022,6 +1030,7 @@ USE_CLIB2=yes
 
 # Don't use SDL on AmigaOS
 USE_SDL=no
+# Use SDL-1.2 for now, if actually using SDL.
 SDL_API=1
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no

--- a/engine/hexen2/Makefile.os2
+++ b/engine/hexen2/Makefile.os2
@@ -25,6 +25,9 @@ OSLIBS=$(UHEXEN2_TOP)/oslibs
 
 # GENERAL OPTIONS (customize as required)
 
+# which major SDL version to use (1: SDL-1.2, 2: SDL-2.0)
+SDL_API    = 1
+
 # link to the opengl libraries at compile time? (defaults
 # to no, so the binaries will dynamically load the necessary
 # libraries and functions at runtime.)
@@ -124,20 +127,28 @@ USE_CODEC_OPUS=no
 
 NASMFLAGS=-f obj -d__OS2__ -d_NO_PREFIX
 
+!ifeq SDL_API 2
+SDL_DIR=SDL2
+LIB_SDL=SDL2
+!else
+SDL_DIR=SDL
+LIB_SDL=SDL12
+!endif
+
 !ifndef __UNIX__
 INCLUDES+= -I$(OSLIBS)\os2\codecs\include
 CODECLIBS=  $(OSLIBS)\os2\codecs\lib\
-SDL_CFLAGS=-I$(OSLIBS)\os2\SDL\include
-SDL_LIBS = $(OSLIBS)\os2\SDL\lib\SDL12.lib
+SDL_CFLAGS=-I$(OSLIBS)\os2\$(SDL_DIR)\include
+SDL_LIBS = $(OSLIBS)\os2\$(SDL_DIR)\lib\$(LIB_SDL).lib
 !else
 INCLUDES+= -I$(OSLIBS)/os2/codecs/include
 CODECLIBS=  $(OSLIBS)/os2/codecs/lib/
-SDL_CFLAGS=-I$(OSLIBS)/os2/SDL/include
-SDL_LIBS = $(OSLIBS)/os2/SDL/lib/SDL12.lib
+SDL_CFLAGS=-I$(OSLIBS)/os2/$(SDL_DIR)/include
+SDL_LIBS = $(OSLIBS)/os2/$(SDL_DIR)/lib/$(LIB_SDL).lib
 !endif
 
 # use SDL for now
-CPPFLAGS+= -DSDLQUAKE
+CPPFLAGS+= -DSDLQUAKE=$(SDL_API)
 CFLAGS  += $(SDL_CFLAGS)
 LIBS    += $(SDL_LIBS)
 

--- a/engine/hexen2/sys_unix.c
+++ b/engine/hexen2/sys_unix.c
@@ -50,9 +50,6 @@
 #include "sdl_inc.h"
 #endif	/* SDLQUAKE */
 
-#if SDLQUAKE == 2
-extern SDL_Window *window;
-#endif
 
 // heapsize: minimum 16mb, standart 32 mb, max is 96 mb.
 // -heapsize argument will abide by these min/max settings
@@ -578,12 +575,10 @@ static int Sys_GetUserdir (char *dst, size_t dstsize)
 static void Sys_CheckSDL (void)
 {
 #if defined(SDLQUAKE)
-#if SDLQUAKE == 2
-	SDL_version local_sdl_version;
-#endif
 	const SDL_version *sdl_version;
+#if (SDLQUAKE > 1)
+	SDL_version local_sdl_version;
 
-#if SDLQUAKE == 2
 	SDL_GetVersion(&local_sdl_version);
 	sdl_version = &local_sdl_version;
 #else
@@ -687,6 +682,9 @@ static char	userdir[MAX_OSPATH];
 #endif
 #if defined(SDLQUAKE)
 static Uint8		appState;
+#if (SDLQUAKE > 1)
+extern SDL_Window	*window;
+#endif
 #endif
 
 int main (int argc, char **argv)
@@ -803,34 +801,33 @@ int main (int argc, char **argv)
 	    else
 	    {
 #if defined(SDLQUAKE)
-#if SDLQUAKE == 2
+#if (SDLQUAKE > 1)
 		appState = SDL_GetWindowFlags(window);
-#else
-		appState = SDL_GetAppState();
-#endif
 		/* If we have no input focus at all, sleep a bit */
-#if SDLQUAKE == 2
-		if ( !(appState & (SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_INPUT_FOCUS)) || cl.paused)
-#else
-		if ( !(appState & (SDL_APPMOUSEFOCUS | SDL_APPINPUTFOCUS)) || cl.paused)
-#endif
-		{
+		if ( !(appState & (SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_INPUT_FOCUS)) || cl.paused) {
 			usleep (16000);
 		}
 		/* If we're minimised, sleep a bit more */
-#if SDLQUAKE == 2
-		if ( !(appState & SDL_WINDOW_SHOWN))
-#else
-		if ( !(appState & SDL_APPACTIVE))
-#endif
-		{
+		if ( !(appState & SDL_WINDOW_SHOWN)) {
 			scr_skipupdate = 1;
 			usleep (32000);
-		}
-		else
-		{
+		} else {
 			scr_skipupdate = 0;
 		}
+#else
+		appState = SDL_GetAppState();
+		/* If we have no input focus at all, sleep a bit */
+		if ( !(appState & (SDL_APPMOUSEFOCUS | SDL_APPINPUTFOCUS)) || cl.paused) {
+			usleep (16000);
+		}
+		/* If we're minimised, sleep a bit more */
+		if ( !(appState & SDL_APPACTIVE)) {
+			scr_skipupdate = 1;
+			usleep (32000);
+		} else {
+			scr_skipupdate = 0;
+		}
+#endif
 #endif	/* SDLQUAKE */
 		newtime = Sys_DoubleTime ();
 		time = newtime - oldtime;

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -51,8 +51,7 @@ OSLIBS:=$(UHEXEN2_TOP)/oslibs
 # X directory
 X11BASE    =/usr/X11R6
 
-# which major SDL version to use
-# ignored for legacy platforms without SDL2 support
+# which major SDL version to use (1: SDL-1.2, 2: SDL-2.0)
 SDL_API    = 2
 
 # the sdl-config command
@@ -469,9 +468,16 @@ LDFLAGS += -s
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # using SDL for now:
-SDL_API=1
-SDL_CFLAGS=-I$(OSLIBS)/os2/SDL/include
-SDL_LIBS = -L$(OSLIBS)/os2/SDL/lib -lSDL12
+ifeq ($(SDL_API),2)
+SDL_DIR=SDL2
+LIB_SDL=SDL2
+else
+SDL_DIR=SDL
+LIB_SDL=SDL12
+endif
+
+SDL_CFLAGS=-I$(OSLIBS)/os2/$(SDL_DIR)/include
+SDL_LIBS = -L$(OSLIBS)/os2/$(SDL_DIR)/lib -l$(LIB_SDL)
 USE_SDLCD=yes
 USE_SDLAUDIO=yes
 
@@ -810,6 +816,7 @@ ifeq ($(TARGET_OS),morphos)
 
 # MorphOS builds can use SDL or native code
 USE_SDL=no
+# Use SDL-1.2 for now, if actually using SDL.
 SDL_API=1
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no
@@ -887,6 +894,7 @@ ifeq ($(TARGET_OS),aros)
 
 # AROS builds can use SDL or native code
 USE_SDL=no
+# Use SDL-1.2 for now, if actually using SDL.
 SDL_API=1
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no
@@ -973,6 +981,7 @@ USE_CLIB2=yes
 
 # Don't use SDL on AmigaOS
 USE_SDL=no
+# Use SDL-1.2 for now, if actually using SDL.
 SDL_API=1
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no

--- a/engine/hexenworld/client/Makefile.os2
+++ b/engine/hexenworld/client/Makefile.os2
@@ -29,6 +29,9 @@ OSLIBS=$(UHEXEN2_TOP)/oslibs
 
 # GENERAL OPTIONS (customize as required)
 
+# which major SDL version to use (1: SDL-1.2, 2: SDL-2.0)
+SDL_API    = 2
+
 # link to the opengl libraries at compile time? (defaults
 # to no, so the binaries will dynamically load the necessary
 # libraries and functions at runtime.)
@@ -130,20 +133,28 @@ USE_CODEC_OPUS=no
 
 NASMFLAGS=-f obj -d__OS2__ -d_NO_PREFIX
 
+!ifeq SDL_API 2
+SDL_DIR=SDL2
+LIB_SDL=SDL2
+!else
+SDL_DIR=SDL
+LIB_SDL=SDL12
+!endif
+
 !ifndef __UNIX__
 INCLUDES+= -I$(OSLIBS)\os2\codecs\include
 CODECLIBS=  $(OSLIBS)\os2\codecs\lib\
-SDL_CFLAGS=-I$(OSLIBS)\os2\SDL\include
-SDL_LIBS = $(OSLIBS)\os2\SDL\lib\SDL12.lib
+SDL_CFLAGS=-I$(OSLIBS)\os2\$(SDL_DIR)\include
+SDL_LIBS = $(OSLIBS)\os2\$(SDL_DIR)\lib\$(LIB_SDL).lib
 !else
 INCLUDES+= -I$(OSLIBS)/os2/codecs/include
 CODECLIBS=  $(OSLIBS)/os2/codecs/lib/
-SDL_CFLAGS=-I$(OSLIBS)/os2/SDL/include
-SDL_LIBS = $(OSLIBS)/os2/SDL/lib/SDL12.lib
+SDL_CFLAGS=-I$(OSLIBS)/os2/$(SDL_DIR)/include
+SDL_LIBS = $(OSLIBS)/os2/$(SDL_DIR)/lib/$(LIB_SDL).lib
 !endif
 
 # use SDL for now
-CPPFLAGS+= -DSDLQUAKE
+CPPFLAGS+= -DSDLQUAKE=$(SDL_API)
 CFLAGS  += $(SDL_CFLAGS)
 LIBS    += $(SDL_LIBS)
 


### PR DESCRIPTION
- os/2 works. plus some tidy-ups (nowhere near complete yet)

 - cd_sdl.c: replace #warning directive with #pragma message.

This is as far as I go with updates.

It needs some serious clean-up before merging into mainstream.
(quakespasm has good SDL2 port, I'll have to take some bits from
there..)